### PR TITLE
Adapt Pure Interface guidelines

### DIFF
--- a/naming_formatting.html
+++ b/naming_formatting.html
@@ -409,7 +409,7 @@ enum UrlTableErrors { ...</PRE></DIV>
           link
         </A></SPAN><SPAN class="showhide_button" onclick="javascript:ShowHideByName('Interface_Names')" name="Interface_Names__button" id="Interface_Names__button">▶</SPAN>
 	<DIV style="display:inline;" class="">
-		<a href="#Interfaces">Pure interfaces</a> must be suffixed with "Interface".
+		The "Interface" suffix can optionally be used only if a class matches the <I><a href="https://htmlpreview.github.io/?https://github.com/AliceO2Group/CodingGuidelines/blob/master/coding_guidelines.html#Interfaces">Pure Interface</a></I> requirements.
      	</DIV>
 	<DIV class=""><DIV class="stylepoint_body" name="Interface_Names__body" id="Interface_Names__body" style="display: none">
 	   <DIV class=""><PRE>// pure interface


### PR DESCRIPTION
This reestablishes the original intention of the Google Coding Guidelines when discussing [Pure interfaces](https://google.github.io/styleguide/cppguide.html#Interfaces). I.e. the `Interface` suffix should not be considered a requirement for so called "Pure interfaces" but usage of the `Interface` suffix can be done only when certain requirements are matched.