### PR TITLE
Add O2CodeCheck instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,25 @@ clang-format -style=file <SOURCEFILE> | diff <SOURCEFILE> -
 A number of config files are available [here](https://github.com/AliceO2Group/CodingGuidelines) for various IDEs.
 
 ### O2 code checker
-All the AliceO2 pull requests are being tested with [O2 CodeChecker](https://github.com/AliceO2Group/O2CodeChecker#readme) during  `build/O2/fullCI` check. It is a bit more strict tool than `clang-format`. Contributors are encouraged to run the codecheck locally before proposing pull request in order to save checking time and CPU resources of testing facilities. Try to run it in root directory of your installation:
+All the AliceO2 pull requests are subject to be tested with [O2 CodeChecker](https://github.com/AliceO2Group/O2CodeChecker#readme) during  `build/O2/fullCI` check. It is a bit stricter tool than `clang-format`. Contributors are encouraged to run the codecheck locally before creating pull request in order to save checking time and CPU resources of testing facilities. Try to run it in root directory of your installation:
 ```
 aliBuild build o2checkcode --defaults o2
+```
+In case of success you'll be informed of it:
+```
+==> Build of o2checkcode successfully completed on `your-pc-name'.
+```
+Otherwise an ERROR messages will appear:
+```
+==> Building o2checkcode@1.0
+==> o2checkcode is being built (use --debug for full output): failed
+ERROR: Error while executing /your/path/sw/SPECS/ubuntu2004_x86-64/o2checkcode/1.0-local1/build.sh on `your-pc-name'.
+ERROR: Log can be found in /your/path/sw/BUILD/o2checkcode-latest/log
+```
+You'll find details of the problem at the end of logfile: `/your/path/sw/BUILD/o2checkcode-latest/log`. For example:
+```
+========== List of errors found ==========
+/sw/SOURCES/O2/7084-slc8_x86-64/0/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h:78:3: error: use '= default' to define a trivial destructor [modernize-use-equals-default]
 ```
 
 ### Configuration files for editors

--- a/README.md
+++ b/README.md
@@ -96,11 +96,16 @@ Otherwise an ERROR messages will appear:
 ERROR: Error while executing /your/path/sw/SPECS/ubuntu2004_x86-64/o2checkcode/1.0-local1/build.sh on `your-pc-name'.
 ERROR: Log can be found in /your/path/sw/BUILD/o2checkcode-latest/log
 ```
-You'll find details of the problem at the end of logfile: `/your/path/sw/BUILD/o2checkcode-latest/log`. For example:
+You'll find details of the problem at the __end__ of logfile: `/your/path/sw/BUILD/o2checkcode-latest/log`. For example:
 ```
 ========== List of errors found ==========
 /sw/SOURCES/O2/7084-slc8_x86-64/0/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h:78:3: error: use '= default' to define a trivial destructor [modernize-use-equals-default]
 ```
+There could be other errors before `========== List of errors found ==========` but they are not relevant. Important ones go after the mentioned line.
+
+The use of o2checkcode is tested at CC8/CS8 and Ubuntu 20.04.3 LTS. People reported failure of successful running o2checkcode on other systems. Alternative ways to run code checker are following:
+1. Try above mentioned way in a Docker container used for CI tests, namely `alisw/slc8-gpu-builder`;
+2. Run O2CodeChecker manually in build directory of O2 project. The instructions can be found [here](https://github.com/AliceO2Group/O2CodeChecker#usage).
 
 ### Configuration files for editors
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ clang-format -style=file <SOURCEFILE> | diff <SOURCEFILE> -
 #### Using an IDE
 A number of config files are available [here](https://github.com/AliceO2Group/CodingGuidelines) for various IDEs.
 
+### O2 code checker
+All the AliceO2 pull requests are being tested with [O2 CodeChecker](https://github.com/AliceO2Group/O2CodeChecker#readme) during  `build/O2/fullCI` check. It is a bit more strict tool than `clang-format`. Contributors are encouraged to run the codecheck locally before proposing pull request in order to save checking time and CPU resources of testing facilities. Try to run it in root directory of your installation:
+```
+aliBuild build o2checkcode --defaults o2
+```
 
 ### Configuration files for editors
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ clang-format -style=file <SOURCEFILE> | diff <SOURCEFILE> -
 A number of config files are available [here](https://github.com/AliceO2Group/CodingGuidelines) for various IDEs.
 
 ### O2 code checker
-All the AliceO2 pull requests are subject to be tested with [O2 CodeChecker](https://github.com/AliceO2Group/O2CodeChecker#readme) during  `build/O2/fullCI` check. It is a bit stricter tool than `clang-format`. Contributors are encouraged to run the codecheck locally before creating pull request in order to save checking time and CPU resources of testing facilities. Try to run it in root directory of your installation:
+All the AliceO2 pull requests are subject to be tested with [O2 CodeChecker](https://github.com/AliceO2Group/O2CodeChecker#readme) during  `build/O2/fullCI` check. It is a bit stricter tool than `clang-format`. Contributors are encouraged to run the codecheck locally before creating a pull request in order to save checking time and CPU resources of the testing facilities. Try to run it in the root directory of your installation:
 ```
 aliBuild build o2checkcode --defaults o2
 ```


### PR DESCRIPTION
Hello, all !
I tried to prepare several strings of explaining o2checkcode usage folowing the conversation with @davidrohr :
 https://github.com/AliceO2Group/AliceO2/pull/7084#issuecomment-925284325
David said that this way is not always work so maybe we need to add some more info (but what?)
Cheers,
Sergey 